### PR TITLE
Add Intel Stratix V Hard IP for PCI Express (Avalon-ST) model

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ The core PCIe simulation framework is included in `cocotbext.pcie.core`.  This f
 
 Models of the Xilinx UltraScale and UltraScale+ PCIe hard cores are included in `cocotbext.pcie.xilinx.us`.  These modules can be used in combination with the PCIe BFM to test an HDL design that targets Xilinx UltraScale, UltraScale+, or Virtex 7 series FPGAs, up to PCIe gen 3 x16 or PCIe gen 4 x8.  The models currently only support operation as a device, not as a root port.
 
+#### Intel Stratix V
+
+Models of the Intel Stratix V Hard IP for PCI Express (Avalon-ST interface) are included in `cocotbext.pcie.intel.s5`.  These modules can be used in combination with the PCIe BFM to test an HDL design that targets Intel Stratix V GX/GT/GS or Arria V GZ series FPGAs, up to PCIe gen 3 x8.  The models currently only support operation as a device, not as a root port, and only a single physical function is supported (multi-function operation requires the SR-IOV variant of the IP, which multiplexes its configuration space differently).
+
+Only the 128-bit and 256-bit Avalon-ST widths are implemented; the 64-bit width, which uses dword-granular byte enables instead of the qword `empty` field, is not supported.  Because the Application Layer clock frequency is a function of link width, link rate, and interface width, the set of valid configurations is correspondingly restricted &mdash; for example gen1 is only available as x8 at 125 MHz on the 128-bit interface, since every narrower gen1 configuration uses the 64-bit interface.
+
+TLP headers and payload are packed on the wire with qword alignment, matching the aligned-address timing diagrams in the user guide; the additional dword-shifted layout used for non-qword-aligned addresses is not modeled.  The `tl_cfg_ctl` multiplex reproduces the full 16-entry register layout and holds each index for eight `pld_clk` cycles, so the strobe-based sampling logic recommended by the user guide works against the model.  `rx_st_mask` is honored for non-posted requests, but the RX path is modeled as a single queue, so a stalled non-posted request also blocks TLPs queued behind it.
+
 #### Intel Stratix 10 H-Tile/L-Tile
 
 Models of the Intel Stratix 10 H-Tile/L-Tile PCIe hard cores are included in `cocotbext.pcie.intel.s10`.  These modules can be used in combination with the PCIe BFM to test an HDL design that targets Intel Stratix 10 GX, SX, TX, and MX series FPGAs that contain H-Tiles or L-Tiles, up to PCIe gen 3 x16.  The models currently only support operation as a device, not as a root port.

--- a/cocotbext/pcie/intel/s5/__init__.py
+++ b/cocotbext/pcie/intel/s5/__init__.py
@@ -1,0 +1,26 @@
+"""
+
+Copyright (c) 2026 Anderson Ignacio da Silva
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+"""
+
+from .s5_model import S5PcieDevice, S5PcieFunction
+from .interface import S5RxBus, S5TxBus

--- a/cocotbext/pcie/intel/s5/interface.py
+++ b/cocotbext/pcie/intel/s5/interface.py
@@ -28,6 +28,7 @@ import struct
 import cocotb
 from cocotb.queue import Queue, QueueFull
 from cocotb.triggers import RisingEdge, Timer, First, Event
+from cocotb.handle import Immediate
 from cocotb_bus.bus import Bus
 
 from cocotbext.pcie.core.tlp import Tlp, TlpType
@@ -339,19 +340,19 @@ class S5PcieSource(S5PcieBase):
         self.queue_occupancy_limit_bytes = -1
         self.queue_occupancy_limit_frames = -1
 
-        self.bus.data.setimmediatevalue(0)
-        self.bus.sop.setimmediatevalue(0)
-        self.bus.eop.setimmediatevalue(0)
-        self.bus.valid.setimmediatevalue(0)
+        self.bus.data.value = Immediate(0)
+        self.bus.sop.value = Immediate(0)
+        self.bus.eop.value = Immediate(0)
+        self.bus.valid.value = Immediate(0)
 
         if hasattr(self.bus, "empty"):
-            self.bus.empty.setimmediatevalue(0)
+            self.bus.empty.value = Immediate(0)
         if hasattr(self.bus, "err"):
-            self.bus.err.setimmediatevalue(0)
+            self.bus.err.value = Immediate(0)
         if hasattr(self.bus, "bar"):
-            self.bus.bar.setimmediatevalue(0)
+            self.bus.bar.value = Immediate(0)
         if hasattr(self.bus, "parity"):
-            self.bus.parity.setimmediatevalue(0)
+            self.bus.parity.value = Immediate(0)
 
         cocotb.start_soon(self._run_source())
         cocotb.start_soon(self._run())
@@ -501,7 +502,7 @@ class S5PcieSink(S5PcieBase):
         self.queue_occupancy_limit_bytes = -1
         self.queue_occupancy_limit_frames = -1
 
-        self.bus.ready.setimmediatevalue(0)
+        self.bus.ready.value = Immediate(0)
 
         cocotb.start_soon(self._run_sink())
         cocotb.start_soon(self._run())

--- a/cocotbext/pcie/intel/s5/interface.py
+++ b/cocotbext/pcie/intel/s5/interface.py
@@ -30,7 +30,7 @@ from cocotb.queue import Queue, QueueFull
 from cocotb.triggers import RisingEdge, Timer, First, Event
 from cocotb_bus.bus import Bus
 
-from cocotbext.pcie.core.tlp import Tlp
+from cocotbext.pcie.core.tlp import Tlp, TlpType
 
 # NOTE: this models the "single packet per cycle" mode of the Stratix V Hard
 # IP for PCI Express, Avalon-ST interface (UG-01097_avst). Only the 128-bit
@@ -100,11 +100,34 @@ class S5PcieFrame:
             hdr_dwords = []
             for k in range(0, len(hdr), 4):
                 hdr_dwords.extend(struct.unpack_from('>L', hdr, k))
-            if len(hdr_dwords) % 2:
-                # pad header to qword boundary
-                hdr_dwords.append(0)
 
             data = frame.get_data()
+
+            if data:
+                # The Hard IP aligns the payload to a qword boundary measured
+                # against the TLP's own low address bit, not against header
+                # length alone (UG-01097_avst "qword aligned address"
+                # framing): a pad dword follows the header only when the
+                # header's own dword parity disagrees with address bit 2.
+                # Getting this wrong drops every payload dword silently
+                # against a real Stratix V hard IP or RTL that implements it
+                # (mate_tlp_rx.sv/mate_tlp_tx.sv/mate_dma_tlp.sv mirror this
+                # as `payload_dw = addr[2] ? <hdr_len> : <hdr_len>+1`, and the
+                # symmetric case for 4DW headers).
+                if frame.fmt_type in {TlpType.CPL, TlpType.CPL_DATA,
+                                      TlpType.CPL_LOCKED,
+                                      TlpType.CPL_LOCKED_DATA}:
+                    addr_bit2 = bool(frame.lower_address & 0x4)
+                else:
+                    addr_bit2 = bool(frame.address & 0x4)
+
+                if (len(hdr_dwords) % 2) != int(addr_bit2):
+                    hdr_dwords.append(0)
+            elif len(hdr_dwords) % 2:
+                # header-only TLP: no payload placement to get right, pad to
+                # qword boundary unconditionally as before
+                hdr_dwords.append(0)
+
             data_dwords = []
             for k in range(0, len(data), 4):
                 data_dwords.extend(struct.unpack_from('<L', data, k))
@@ -129,7 +152,6 @@ class S5PcieFrame:
     def to_tlp(self):
         fmt = (self.data[0] >> 29) & 0b111
         hdr_len = 4 if fmt & 0b001 else 3
-        wire_hdr_len = hdr_len + (hdr_len % 2)
 
         hdr = bytearray()
         for dw in self.data[:hdr_len]:
@@ -137,6 +159,17 @@ class S5PcieFrame:
         tlp = Tlp.unpack_header(hdr)
 
         if fmt & 0b010:
+            # Mirror the address-bit-2 payload shift applied in from_tlp()
+            # above, using the address fields already parsed onto `tlp`.
+            if tlp.fmt_type in {TlpType.CPL, TlpType.CPL_DATA,
+                                TlpType.CPL_LOCKED, TlpType.CPL_LOCKED_DATA}:
+                addr_bit2 = bool(tlp.lower_address & 0x4)
+            else:
+                addr_bit2 = bool(tlp.address & 0x4)
+
+            wire_hdr_len = hdr_len if (hdr_len % 2) == int(addr_bit2) \
+                else hdr_len + 1
+
             for dw in self.data[wire_hdr_len:wire_hdr_len+tlp.length]:
                 tlp.data.extend(struct.pack('<L', dw))
 

--- a/cocotbext/pcie/intel/s5/interface.py
+++ b/cocotbext/pcie/intel/s5/interface.py
@@ -1,0 +1,594 @@
+"""
+
+Copyright (c) 2026 Anderson Ignacio da Silva
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+"""
+
+import logging
+import struct
+
+import cocotb
+from cocotb.queue import Queue, QueueFull
+from cocotb.triggers import RisingEdge, Timer, First, Event
+from cocotb_bus.bus import Bus
+
+from cocotbext.pcie.core.tlp import Tlp
+
+# NOTE: this models the "single packet per cycle" mode of the Stratix V Hard
+# IP for PCI Express, Avalon-ST interface (UG-01097_avst). Only the 128-bit
+# and 256-bit Avalon-ST widths are implemented. The 64-bit interface uses a
+# dword-granularity byte-enable scheme (rx_st_be/tx_st_be) instead of the
+# qword-granularity empty field and is not currently supported.
+#
+# The Hard IP always aligns the start of the TLP payload to a qword (64-bit)
+# boundary: a 3-dword header is padded with an extra (unused) dword, and, in
+# this model, an odd-length payload is likewise padded with a trailing unused
+# dword so the whole packet always occupies a whole number of qwords. This
+# matches the "qword aligned address" data/timing figures in the datasheet.
+# The additional dword-shifted layout used for non-qword-aligned addresses
+# (i.e. based on address bit 2) is not modeled.
+
+
+class BaseBus(Bus):
+
+    _signals = ["data"]
+    _optional_signals = []
+
+    def __init__(self, entity=None, prefix=None, **kwargs):
+        super().__init__(entity, prefix, self._signals, optional_signals=self._optional_signals, **kwargs)
+
+    @classmethod
+    def from_entity(cls, entity, **kwargs):
+        return cls(entity, **kwargs)
+
+    @classmethod
+    def from_prefix(cls, entity, prefix, **kwargs):
+        return cls(entity, prefix, **kwargs)
+
+
+class S5TxBus(BaseBus):
+    _signals = ["data", "sop", "eop", "valid", "ready"]
+    _optional_signals = ["empty", "err", "parity"]
+
+
+class S5RxBus(BaseBus):
+    _signals = ["data", "sop", "eop", "valid", "ready"]
+    _optional_signals = ["empty", "err", "bar", "mask", "parity"]
+
+
+def dword_parity(d):
+    d ^= d >> 4
+    d ^= d >> 2
+    d ^= d >> 1
+    p = d & 0x1
+    if d & 0x100:
+        p |= 0x2
+    if d & 0x10000:
+        p |= 0x4
+    if d & 0x1000000:
+        p |= 0x8
+    return p
+
+
+class S5PcieFrame:
+    def __init__(self, frame=None):
+        self.data = []
+        self.parity = []
+        self.bar = 0
+        self.err = 0
+
+        if isinstance(frame, Tlp):
+            hdr = frame.pack_header()
+            hdr_dwords = []
+            for k in range(0, len(hdr), 4):
+                hdr_dwords.extend(struct.unpack_from('>L', hdr, k))
+            if len(hdr_dwords) % 2:
+                # pad header to qword boundary
+                hdr_dwords.append(0)
+
+            data = frame.get_data()
+            data_dwords = []
+            for k in range(0, len(data), 4):
+                data_dwords.extend(struct.unpack_from('<L', data, k))
+            if len(data_dwords) % 2:
+                # pad payload to qword boundary
+                data_dwords.append(0)
+
+            self.data = hdr_dwords + data_dwords
+
+            self.update_parity()
+
+        elif isinstance(frame, S5PcieFrame):
+            self.data = list(frame.data)
+            self.parity = list(frame.parity)
+            self.bar = frame.bar
+            self.err = frame.err
+
+    @classmethod
+    def from_tlp(cls, tlp):
+        return cls(tlp)
+
+    def to_tlp(self):
+        fmt = (self.data[0] >> 29) & 0b111
+        hdr_len = 4 if fmt & 0b001 else 3
+        wire_hdr_len = hdr_len + (hdr_len % 2)
+
+        hdr = bytearray()
+        for dw in self.data[:hdr_len]:
+            hdr.extend(struct.pack('>L', dw))
+        tlp = Tlp.unpack_header(hdr)
+
+        if fmt & 0b010:
+            for dw in self.data[wire_hdr_len:wire_hdr_len+tlp.length]:
+                tlp.data.extend(struct.pack('<L', dw))
+
+        return tlp
+
+    def update_parity(self):
+        self.parity = [dword_parity(d) ^ 0xf for d in self.data]
+
+    def check_parity(self):
+        return (
+            self.parity == [dword_parity(d) ^ 0xf for d in self.data]
+        )
+
+    def __eq__(self, other):
+        if isinstance(other, S5PcieFrame):
+            return (
+                self.data == other.data and
+                self.parity == other.parity and
+                self.bar == other.bar and
+                self.err == other.err
+            )
+        return False
+
+    def __repr__(self):
+        return (
+            f"{type(self).__name__}(data=[{', '.join(f'{x:#010x}' for x in self.data)}], "
+            f"parity=[{', '.join(hex(x) for x in self.parity)}], "
+            f"bar={self.bar:#04x}, "
+            f"err={self.err})"
+        )
+
+    def __len__(self):
+        return len(self.data)
+
+
+class S5PcieTransaction:
+
+    _signals = ["data", "empty", "sop", "eop", "valid", "err", "bar", "parity"]
+
+    def __init__(self, *args, **kwargs):
+        for sig in self._signals:
+            if sig in kwargs:
+                setattr(self, sig, kwargs[sig])
+                del kwargs[sig]
+            else:
+                setattr(self, sig, 0)
+
+        super().__init__(*args, **kwargs)
+
+    def __repr__(self):
+        return f"{type(self).__name__}({', '.join(f'{s}={int(getattr(self, s))}' for s in self._signals)})"
+
+
+class S5PcieBase:
+
+    _signal_widths = {"ready": 1}
+
+    _valid_signal = "valid"
+    _ready_signal = "ready"
+
+    _transaction_obj = S5PcieTransaction
+    _frame_obj = S5PcieFrame
+
+    def __init__(self, bus, clock, reset=None, ready_latency=0, *args, **kwargs):
+        self.bus = bus
+        self.clock = clock
+        self.reset = reset
+        self.ready_latency = ready_latency
+        if bus._name:
+            self.log = logging.getLogger(f"cocotb.{bus._entity._name}.{bus._name}")
+        else:
+            self.log = logging.getLogger(f"cocotb.{bus._entity._name}")
+
+        super().__init__(*args, **kwargs)
+
+        self.active = False
+        self.queue = Queue()
+        self.dequeue_event = Event()
+        self.idle_event = Event()
+        self.idle_event.set()
+        self.active_event = Event()
+
+        self.pause = False
+        self._pause_generator = None
+        self._pause_cr = None
+
+        self.queue_occupancy_bytes = 0
+        self.queue_occupancy_frames = 0
+
+        self.width = len(self.bus.data)
+        self.byte_size = 32
+        self.byte_lanes = self.width // self.byte_size
+        self.byte_mask = 2**self.byte_size-1
+
+        self.qword_lanes = self.width // 64
+        self.empty_width = (self.qword_lanes-1).bit_length()
+        self.empty_mask = 2**self.empty_width-1 if self.empty_width else 0
+        self.par_width = self.width // 8
+
+        assert self.width in {128, 256}, "only 128-bit and 256-bit Avalon-ST widths are currently supported"
+
+        if hasattr(self.bus, "empty"):
+            # the datasheet declares rx_st_empty/tx_st_empty as [1:0] regardless
+            # of interface width, but only the low bits apply for the 128-bit
+            # interface, so accept anything wide enough to carry the encoding
+            assert self.empty_width <= len(self.bus.empty) <= 2
+        if hasattr(self.bus, "bar"):
+            assert len(self.bus.bar) == 8
+        if hasattr(self.bus, "parity"):
+            assert len(self.bus.parity) == self.par_width
+
+    def count(self):
+        return self.queue.qsize()
+
+    def empty(self):
+        return self.queue.empty()
+
+    def clear(self):
+        while not self.queue.empty():
+            self.queue.get_nowait()
+        self.idle_event.set()
+        self.active_event.clear()
+
+    def idle(self):
+        raise NotImplementedError()
+
+    async def wait(self):
+        raise NotImplementedError()
+
+    def set_pause_generator(self, generator=None):
+        if self._pause_cr is not None:
+            self._pause_cr.kill()
+            self._pause_cr = None
+
+        self._pause_generator = generator
+
+        if self._pause_generator is not None:
+            self._pause_cr = cocotb.start_soon(self._run_pause())
+
+    def clear_pause_generator(self):
+        self.set_pause_generator(None)
+
+    async def _run_pause(self):
+        clock_edge_event = RisingEdge(self.clock)
+
+        for val in self._pause_generator:
+            self.pause = val
+            await clock_edge_event
+
+
+class S5PcieSource(S5PcieBase):
+
+    _signal_widths = {"valid": 1, "ready": 1}
+
+    _valid_signal = "valid"
+    _ready_signal = "ready"
+
+    _transaction_obj = S5PcieTransaction
+    _frame_obj = S5PcieFrame
+
+    def __init__(self, bus, clock, reset=None, ready_latency=0, *args, **kwargs):
+        super().__init__(bus, clock, reset, ready_latency, *args, **kwargs)
+
+        self.drive_obj = None
+        self.drive_sync = Event()
+
+        self.queue_occupancy_limit_bytes = -1
+        self.queue_occupancy_limit_frames = -1
+
+        self.bus.data.setimmediatevalue(0)
+        self.bus.sop.setimmediatevalue(0)
+        self.bus.eop.setimmediatevalue(0)
+        self.bus.valid.setimmediatevalue(0)
+
+        if hasattr(self.bus, "empty"):
+            self.bus.empty.setimmediatevalue(0)
+        if hasattr(self.bus, "err"):
+            self.bus.err.setimmediatevalue(0)
+        if hasattr(self.bus, "bar"):
+            self.bus.bar.setimmediatevalue(0)
+        if hasattr(self.bus, "parity"):
+            self.bus.parity.setimmediatevalue(0)
+
+        cocotb.start_soon(self._run_source())
+        cocotb.start_soon(self._run())
+
+    async def _drive(self, obj):
+        if self.drive_obj is not None:
+            self.drive_sync.clear()
+            await self.drive_sync.wait()
+
+        self.drive_obj = obj
+
+    async def send(self, frame):
+        while self.full():
+            self.dequeue_event.clear()
+            await self.dequeue_event.wait()
+        frame = S5PcieFrame(frame)
+        await self.queue.put(frame)
+        self.idle_event.clear()
+        self.queue_occupancy_bytes += len(frame)
+        self.queue_occupancy_frames += 1
+
+    def send_nowait(self, frame):
+        if self.full():
+            raise QueueFull()
+        frame = S5PcieFrame(frame)
+        self.queue.put_nowait(frame)
+        self.idle_event.clear()
+        self.queue_occupancy_bytes += len(frame)
+        self.queue_occupancy_frames += 1
+
+    def full(self):
+        if self.queue_occupancy_limit_bytes > 0 and self.queue_occupancy_bytes > self.queue_occupancy_limit_bytes:
+            return True
+        elif self.queue_occupancy_limit_frames > 0 and self.queue_occupancy_frames > self.queue_occupancy_limit_frames:
+            return True
+        else:
+            return False
+
+    def idle(self):
+        return self.empty() and not self.active
+
+    async def wait(self):
+        await self.idle_event.wait()
+
+    async def _run_source(self):
+        self.active = False
+        ready_delay = []
+
+        clock_edge_event = RisingEdge(self.clock)
+
+        while True:
+            await clock_edge_event
+
+            ready_sample = self.bus.ready.value
+            valid_sample = self.bus.valid.value
+
+            if self.reset is not None and self.reset.value:
+                self.active = False
+                self.bus.valid.value = 0
+                continue
+
+            if self.ready_latency > 1:
+                if len(ready_delay) != (self.ready_latency-1):
+                    ready_delay = [0]*(self.ready_latency-1)
+                ready_delay.append(ready_sample)
+                ready_sample = ready_delay.pop(0)
+
+            if (ready_sample and valid_sample) or not valid_sample or self.ready_latency > 0:
+                if self.drive_obj and not self.pause and (ready_sample or self.ready_latency == 0):
+                    self.bus.drive(self.drive_obj)
+                    self.drive_obj = None
+                    self.drive_sync.set()
+                    self.active = True
+                else:
+                    self.bus.valid.value = 0
+                    self.active = bool(self.drive_obj)
+                    if not self.drive_obj:
+                        self.idle_event.set()
+
+    async def _run(self):
+        while True:
+            frame = await self._get_frame()
+            frame_offset = 0
+            self.log.info("TX frame: %r", frame)
+
+            while frame_offset < len(frame.data):
+                transaction = self._transaction_obj()
+
+                n = min(self.byte_lanes, len(frame.data)-frame_offset)
+
+                data = 0
+                parity = 0
+                for k in range(n):
+                    data |= frame.data[frame_offset+k] << 32*k
+                    if frame.parity:
+                        parity |= frame.parity[frame_offset+k] << 4*k
+
+                transaction.data = data
+                transaction.parity = parity
+                transaction.valid = 1
+                transaction.bar = frame.bar
+                transaction.err = frame.err
+
+                if frame_offset == 0:
+                    transaction.sop = 1
+
+                frame_offset += n
+
+                if frame_offset >= len(frame.data):
+                    transaction.eop = 1
+                    empty_dwords = self.byte_lanes-n
+                    transaction.empty = (empty_dwords // 2) & self.empty_mask
+
+                await self._drive(transaction)
+
+    async def _get_frame(self):
+        frame = await self.queue.get()
+        self.dequeue_event.set()
+        self.queue_occupancy_bytes -= len(frame)
+        self.queue_occupancy_frames -= 1
+        return frame
+
+    def _get_frame_nowait(self):
+        frame = self.queue.get_nowait()
+        self.dequeue_event.set()
+        self.queue_occupancy_bytes -= len(frame)
+        self.queue_occupancy_frames -= 1
+        return frame
+
+
+class S5PcieSink(S5PcieBase):
+
+    _signal_widths = {"valid": 1, "ready": 1}
+
+    _valid_signal = "valid"
+    _ready_signal = "ready"
+
+    _transaction_obj = S5PcieTransaction
+    _frame_obj = S5PcieFrame
+
+    def __init__(self, bus, clock, reset=None, ready_latency=0, *args, **kwargs):
+        super().__init__(bus, clock, reset, ready_latency, *args, **kwargs)
+
+        self.sample_obj = None
+        self.sample_sync = Event()
+
+        self.queue_occupancy_limit_bytes = -1
+        self.queue_occupancy_limit_frames = -1
+
+        self.bus.ready.setimmediatevalue(0)
+
+        cocotb.start_soon(self._run_sink())
+        cocotb.start_soon(self._run())
+
+    def _recv(self, frame):
+        if self.queue.empty():
+            self.active_event.clear()
+        self.queue_occupancy_bytes -= len(frame)
+        self.queue_occupancy_frames -= 1
+        return frame
+
+    async def recv(self):
+        frame = await self.queue.get()
+        return self._recv(frame)
+
+    def recv_nowait(self):
+        frame = self.queue.get_nowait()
+        return self._recv(frame)
+
+    def full(self):
+        if self.queue_occupancy_limit_bytes > 0 and self.queue_occupancy_bytes > self.queue_occupancy_limit_bytes:
+            return True
+        elif self.queue_occupancy_limit_frames > 0 and self.queue_occupancy_frames > self.queue_occupancy_limit_frames:
+            return True
+        else:
+            return False
+
+    def idle(self):
+        return not self.active
+
+    async def wait(self, timeout=0, timeout_unit='ns'):
+        if not self.empty():
+            return
+        if timeout:
+            await First(self.active_event.wait(), Timer(timeout, timeout_unit))
+        else:
+            await self.active_event.wait()
+
+    async def _run_sink(self):
+        ready_delay = []
+
+        clock_edge_event = RisingEdge(self.clock)
+
+        while True:
+            await clock_edge_event
+
+            ready_sample = self.bus.ready.value
+            valid_sample = self.bus.valid.value
+
+            if self.reset is not None and self.reset.value:
+                self.bus.ready.value = 0
+                continue
+
+            if self.ready_latency > 0:
+                if len(ready_delay) != self.ready_latency:
+                    ready_delay = [0]*self.ready_latency
+                ready_delay.append(ready_sample)
+                ready_sample = ready_delay.pop(0)
+
+            if valid_sample and ready_sample:
+                self.sample_obj = self._transaction_obj()
+                self.bus.sample(self.sample_obj)
+                self.sample_sync.set()
+            elif self.ready_latency > 0:
+                assert not valid_sample, "handshake error: valid asserted outside of ready cycle"
+
+            self.bus.ready.value = (not self.full() and not self.pause)
+
+    async def _run(self):
+        self.active = False
+        frame = None
+        err = 0
+
+        while True:
+            while not self.sample_obj:
+                self.sample_sync.clear()
+                await self.sample_sync.wait()
+
+            self.active = True
+            sample = self.sample_obj
+            self.sample_obj = None
+
+            if int(sample.sop):
+                assert frame is None, "framing error: sop asserted in frame"
+                frame = S5PcieFrame()
+                frame.bar = int(sample.bar)
+                err = 0
+
+            assert frame is not None, "framing error: data transferred outside of frame"
+
+            data = int(sample.data)
+            parity = int(sample.parity)
+            for k in range(self.byte_lanes):
+                frame.data.append((data >> 32*k) & 0xffffffff)
+                frame.parity.append((parity >> 4*k) & 0xf)
+
+            err |= int(sample.err)
+
+            if int(sample.eop):
+                empty_dwords = (int(sample.empty) & self.empty_mask) * 2
+                if empty_dwords:
+                    del frame.data[-empty_dwords:]
+                    del frame.parity[-empty_dwords:]
+
+                frame.err = err
+
+                self.log.info("RX frame: %r", frame)
+                self._sink_frame(frame)
+                self.active = False
+                frame = None
+
+    def _sink_frame(self, frame):
+        self.queue_occupancy_bytes += len(frame)
+        self.queue_occupancy_frames += 1
+
+        if frame.err:
+            self.log.warning("Dropping nullified (tx_st_err) TLP: %r", frame)
+            self.queue_occupancy_bytes -= len(frame)
+            self.queue_occupancy_frames -= 1
+            return
+
+        self.queue.put_nowait(frame)
+        self.active_event.set()

--- a/cocotbext/pcie/intel/s5/s5_model.py
+++ b/cocotbext/pcie/intel/s5/s5_model.py
@@ -26,6 +26,7 @@ import cocotb
 from cocotb.clock import Clock
 from cocotb.queue import Queue
 from cocotb.triggers import RisingEdge, FallingEdge, Timer, First
+from cocotb.handle import Immediate
 
 from cocotbext.pcie.core import Device, Endpoint, __version__
 from cocotbext.pcie.core.caps import MsiCapability, MsixCapability
@@ -90,7 +91,7 @@ def init_signal(sig, width=None, initval=None):
     if width is not None:
         assert len(sig) == width
     if initval is not None:
-        sig.setimmediatevalue(initval)
+        sig.value = Immediate(initval)
     return sig
 
 

--- a/cocotbext/pcie/intel/s5/s5_model.py
+++ b/cocotbext/pcie/intel/s5/s5_model.py
@@ -1,0 +1,850 @@
+"""
+
+Copyright (c) 2026 Anderson Ignacio da Silva
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+"""
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.queue import Queue
+from cocotb.triggers import RisingEdge, FallingEdge, Timer, First
+
+from cocotbext.pcie.core import Device, Endpoint, __version__
+from cocotbext.pcie.core.caps import MsiCapability, MsixCapability
+from cocotbext.pcie.core.caps import AerExtendedCapability, PcieExtendedCapability
+from cocotbext.pcie.core.utils import PcieId
+from cocotbext.pcie.core.tlp import Tlp, TlpType
+
+from .interface import S5PcieFrame, S5PcieSource, S5PcieSink
+
+
+# (speed, link width, AVST width, coreclkout_hip/pld_clk frequency)
+#
+# Transcribed from UG-01097_avst Table 7-3 "Application Layer Clock Frequency
+# for All Combinations of Link Width, Data Rate and Application Layer Interface
+# Widths".  Only the rows using a 128-bit or 256-bit Avalon-ST interface are
+# listed here, since the 64-bit interface is not modeled (see interface.py).
+# Note that every gen1/gen2 x1/x2 combination, and gen1 x1/x2/x4, only exist
+# with the 64-bit interface and therefore cannot be represented by this model.
+valid_configs = [
+    (1,  8, 128, 125.0e6),
+    (2,  4, 128, 125.0e6),
+    (2,  8, 128, 250.0e6),
+    (2,  8, 256, 125.0e6),
+    (3,  2, 128, 125.0e6),
+    (3,  4, 128, 250.0e6),
+    # Table 7-3 as printed stops at gen3 x4; the feature list (Table 1-1) and
+    # the datasheet's "x1, x2, x4, and x8 configurations with Gen1, Gen2, or
+    # Gen3 lane rates" statement both claim gen3 x8 support.  Gen3 x8 needs
+    # ~7.88 GB/s, which requires the 256-bit interface at 250 MHz.
+    (3,  8, 256, 250.0e6),
+]
+
+
+class S5PcieFunction(Endpoint):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # PCIe capabilities
+        self.register_capability(self.pm_cap, offset=0x10)
+
+        self.msi_cap = MsiCapability()
+        self.msi_cap.msi_64bit_address_capable = 1
+        self.msi_cap.msi_per_vector_mask_capable = 0
+        self.register_capability(self.msi_cap, offset=0x14)
+
+        self.register_capability(self.pcie_cap, offset=0x1c)
+
+        self.msix_cap = MsixCapability()
+        self.register_capability(self.msix_cap, offset=0x2c)
+
+        # PCIe extended capabilities
+        self.aer_ext_cap = AerExtendedCapability()
+        self.register_capability(self.aer_ext_cap, offset=0x40)
+
+        self.pcie_ext_cap = PcieExtendedCapability()
+        self.register_capability(self.pcie_ext_cap, offset=0x62)
+
+
+def init_signal(sig, width=None, initval=None):
+    if sig is None:
+        return None
+    if width is not None:
+        assert len(sig) == width
+    if initval is not None:
+        sig.setimmediatevalue(initval)
+    return sig
+
+
+class S5PcieDevice(Device):
+    def __init__(self,
+            # configuration options
+            pcie_generation=None,
+            pcie_link_width=None,
+            pld_clk_frequency=None,
+            pf_count=1,
+            max_payload_size=128,
+            enable_extended_tag=False,
+
+            pf0_msi_enable=False,
+            pf0_msi_count=1,
+            pf0_msix_enable=False,
+            pf0_msix_table_size=0,
+            pf0_msix_table_bir=0,
+            pf0_msix_table_offset=0x00000000,
+            pf0_msix_pba_bir=0,
+            pf0_msix_pba_offset=0x00000000,
+
+            # signals
+            # Clocks
+            refclk=None,
+            pld_clk=None,
+            coreclkout=None,
+
+            # Reset, status, and link training
+            npor=None,
+            pin_perst=None,
+            reset_status=None,
+            clr_st=None,
+            serdes_pll_locked=None,
+            pld_core_ready=None,
+            pld_clk_inuse=None,
+            dlup=None,
+            dlup_exit=None,
+            hotrst_exit=None,
+            l2_exit=None,
+            ev128ns=None,
+            ev1us=None,
+            lane_act=None,
+            currentspeed=None,
+            ltssmstate=None,
+
+            # RX interface
+            rx_bus=None,
+
+            # TX interface
+            tx_bus=None,
+
+            # TX flow control (component specific TX credit signals)
+            tx_cred_hdrfcp=None,
+            tx_cred_datafcp=None,
+            tx_cred_hdrfcnp=None,
+            tx_cred_datafcnp=None,
+            tx_cred_hdrfccp=None,
+            tx_cred_datafccp=None,
+            tx_cred_fchipcons=None,
+            tx_cred_fc_infinite=None,
+            tx_cons_cred_sel=None,
+            ko_cpl_spc_header=None,
+            ko_cpl_spc_data=None,
+
+            # Error signals
+            derr_cor_ext_rcv0=None,
+            derr_rpl=None,
+            derr_cor_ext_rpl0=None,
+            rxfc_cplbuf_ovf=None,
+
+            # Interrupts for endpoints
+            app_msi_req=None,
+            app_msi_ack=None,
+            app_msi_tc=None,
+            app_msi_num=None,
+            app_int_sts=None,
+            app_int_ack=None,
+
+            # Interrupts for root ports
+            int_status=None,
+            serr_out=None,
+
+            # Completion side band signals
+            cpl_err=None,
+            cpl_pending=None,
+
+            # Transaction layer configuration space signals
+            tl_cfg_add=None,
+            tl_cfg_ctl=None,
+            tl_cfg_sts=None,
+
+            # Power management
+            pme_to_cr=None,
+            pme_to_sr=None,
+            pm_event=None,
+            pm_data=None,
+            pm_auxpwr=None,
+
+            *args, **kwargs):
+
+        super().__init__(*args, **kwargs)
+
+        self.log.info("Intel Stratix V Hard IP for PCI Express (Avalon-ST) core model")
+        self.log.info("cocotbext-pcie version %s", __version__)
+        self.log.info("Copyright (c) 2026 Anderson Ignacio da Silva")
+
+        self.default_function = S5PcieFunction
+
+        self.dw = None
+
+        self.rx_queue = Queue()
+
+        self.rx_buf_cplh_fc_limit = 32
+        self.rx_buf_cpld_fc_limit = 128
+        self.rx_buf_cplh_fc_count = 0
+        self.rx_buf_cpld_fc_count = 0
+
+        # configuration options
+        self.pcie_generation = pcie_generation
+        self.pcie_link_width = pcie_link_width
+        self.pld_clk_frequency = pld_clk_frequency
+        self.pf_count = pf_count
+        self.max_payload_size = max_payload_size
+        self.enable_extended_tag = enable_extended_tag
+
+        self.pf0_msi_enable = pf0_msi_enable
+        self.pf0_msi_count = pf0_msi_count
+        self.pf0_msix_enable = pf0_msix_enable
+        self.pf0_msix_table_size = pf0_msix_table_size
+        self.pf0_msix_table_bir = pf0_msix_table_bir
+        self.pf0_msix_table_offset = pf0_msix_table_offset
+        self.pf0_msix_pba_bir = pf0_msix_pba_bir
+        self.pf0_msix_pba_offset = pf0_msix_pba_offset
+
+        # signals
+
+        # Clocks
+        self.refclk = init_signal(refclk, 1)
+        self.pld_clk = init_signal(pld_clk, 1)
+        self.coreclkout = init_signal(coreclkout, 1, 0)
+
+        # Reset, status, and link training
+        self.npor = init_signal(npor, 1)
+        self.pin_perst = init_signal(pin_perst, 1)
+        self.reset_status = init_signal(reset_status, 1, 0)
+        self.clr_st = init_signal(clr_st, 1, 0)
+        self.serdes_pll_locked = init_signal(serdes_pll_locked, 1, 0)
+        self.pld_core_ready = init_signal(pld_core_ready, 1)
+        self.pld_clk_inuse = init_signal(pld_clk_inuse, 1, 0)
+        self.dlup = init_signal(dlup, 1, 0)
+        self.dlup_exit = init_signal(dlup_exit, 1, 1)
+        self.hotrst_exit = init_signal(hotrst_exit, 1, 0)
+        self.l2_exit = init_signal(l2_exit, 1, 1)
+        self.ev128ns = init_signal(ev128ns, 1, 0)
+        self.ev1us = init_signal(ev1us, 1, 0)
+        self.lane_act = init_signal(lane_act, 4, 0)
+        self.currentspeed = init_signal(currentspeed, 2, 0)
+        self.ltssmstate = init_signal(ltssmstate, 5, 0)
+
+        # RX interface
+        self.rx_source = None
+        self.rx_st_mask = None
+
+        if rx_bus is not None:
+            self.rx_source = S5PcieSource(rx_bus, self.pld_clk)
+            self.rx_source.queue_occupancy_limit_frames = 2
+            self.rx_source.ready_latency = 3
+            self.dw = self.rx_source.width
+            # rx_st_mask is an Application Layer input that stalls non-posted
+            # requests; it lives on the RX bus rather than being a separate port
+            self.rx_st_mask = getattr(rx_bus, "mask", None)
+
+        # TX interface
+        self.tx_sink = None
+
+        if tx_bus is not None:
+            self.tx_sink = S5PcieSink(tx_bus, self.pld_clk)
+            self.tx_sink.queue_occupancy_limit_frames = 2
+            self.tx_sink.ready_latency = 2
+            self.dw = self.tx_sink.width
+
+        # TX flow control
+        self.tx_cred_hdrfcp = init_signal(tx_cred_hdrfcp, 8, 0)
+        self.tx_cred_datafcp = init_signal(tx_cred_datafcp, 12, 0)
+        self.tx_cred_hdrfcnp = init_signal(tx_cred_hdrfcnp, 8, 0)
+        self.tx_cred_datafcnp = init_signal(tx_cred_datafcnp, 12, 0)
+        self.tx_cred_hdrfccp = init_signal(tx_cred_hdrfccp, 8, 0)
+        self.tx_cred_datafccp = init_signal(tx_cred_datafccp, 12, 0)
+        self.tx_cred_fchipcons = init_signal(tx_cred_fchipcons, 6, 0)
+        self.tx_cred_fc_infinite = init_signal(tx_cred_fc_infinite, 6, 0)
+        self.tx_cons_cred_sel = init_signal(tx_cons_cred_sel, 1)
+        self.ko_cpl_spc_header = init_signal(ko_cpl_spc_header, 8, self.rx_buf_cplh_fc_limit)
+        self.ko_cpl_spc_data = init_signal(ko_cpl_spc_data, 12, self.rx_buf_cpld_fc_limit)
+
+        # Error signals
+        self.derr_cor_ext_rcv0 = init_signal(derr_cor_ext_rcv0, 1, 0)
+        self.derr_rpl = init_signal(derr_rpl, 1, 0)
+        self.derr_cor_ext_rpl0 = init_signal(derr_cor_ext_rpl0, 1, 0)
+        self.rxfc_cplbuf_ovf = init_signal(rxfc_cplbuf_ovf, 1, 0)
+
+        # Interrupts for endpoints
+        self.app_msi_req = init_signal(app_msi_req, 1)
+        self.app_msi_ack = init_signal(app_msi_ack, 1, 0)
+        self.app_msi_tc = init_signal(app_msi_tc, 3)
+        self.app_msi_num = init_signal(app_msi_num, 5)
+        self.app_int_sts = init_signal(app_int_sts, 1)
+        self.app_int_ack = init_signal(app_int_ack, 1, 0)
+
+        # Interrupts for root ports
+        self.int_status = init_signal(int_status, 4, 0)
+        self.serr_out = init_signal(serr_out, 1, 0)
+
+        # Completion side band signals
+        self.cpl_err = init_signal(cpl_err, 7)
+        self.cpl_pending = init_signal(cpl_pending, 1)
+
+        # Transaction layer configuration space signals
+        self.tl_cfg_add = init_signal(tl_cfg_add, 4, 0)
+        self.tl_cfg_ctl = init_signal(tl_cfg_ctl, 32, 0)
+        self.tl_cfg_sts = init_signal(tl_cfg_sts, 53, 0)
+        # number of pld_clk cycles each tl_cfg_add index is held; the datasheet
+        # allows 4 or 8 depending on parameterization (Table 5-16)
+        self.tl_cfg_update_cycles = 8
+
+        # Power management
+        self.pme_to_cr = init_signal(pme_to_cr, 1)
+        self.pme_to_sr = init_signal(pme_to_sr, 1, 0)
+        self.pm_event = init_signal(pm_event, 1)
+        self.pm_data = init_signal(pm_data, 10)
+        self.pm_auxpwr = init_signal(pm_auxpwr, 1)
+
+        # validate parameters
+        assert self.dw in {128, 256}
+
+        # rescale clock frequency
+        if self.pld_clk_frequency is not None and self.pld_clk_frequency < 1e6:
+            self.pld_clk_frequency *= 1e6
+
+        if not self.pcie_generation or not self.pcie_link_width or not self.pld_clk_frequency:
+            self.log.info("Incomplete configuration specified, attempting to select reasonable options")
+            for config in reversed(valid_configs):
+                if self.pcie_generation is not None and self.pcie_generation != config[0]:
+                    continue
+                if self.pcie_link_width is not None and self.pcie_link_width != config[1]:
+                    continue
+                if self.dw != config[2]:
+                    continue
+                if self.pld_clk_frequency is not None and self.pld_clk_frequency != config[3]:
+                    continue
+
+                if self.pcie_generation is None:
+                    self.log.info("Setting PCIe speed to gen %d", config[0])
+                    self.pcie_generation = config[0]
+                if self.pcie_link_width is None:
+                    self.log.info("Setting PCIe link width to x%d", config[1])
+                    self.pcie_link_width = config[1]
+                if self.pld_clk_frequency is None:
+                    self.log.info("Setting pld_clk frequency to %d MHz", config[3]/1e6)
+                    self.pld_clk_frequency = config[3]
+                break
+
+        self.log.info("Intel Stratix V Hard IP for PCI Express configuration:")
+        self.log.info("  PCIe speed: gen %d", self.pcie_generation)
+        self.log.info("  PCIe link width: x%d", self.pcie_link_width)
+        self.log.info("  pld_clk frequency: %d MHz", self.pld_clk_frequency/1e6)
+        self.log.info("  Avalon-ST width: %d", self.dw)
+        self.log.info("  PF count: %d", self.pf_count)
+        self.log.info("  Max payload size: %d", self.max_payload_size)
+        self.log.info("  Enable extended tag: %s", self.enable_extended_tag)
+
+        assert self.pcie_generation in {1, 2, 3}
+        assert self.pcie_link_width in {1, 2, 4, 8}
+        assert self.pf_count == 1, \
+            "this IP variant multiplexes a single function onto tl_cfg_ctl; " \
+            "multi-function requires the SR-IOV variant"
+
+        config_valid = False
+        for config in valid_configs:
+            if self.pcie_generation != config[0]:
+                continue
+            if self.pcie_link_width != config[1]:
+                continue
+            if self.dw != config[2]:
+                continue
+            if self.pld_clk_frequency != config[3]:
+                continue
+
+            config_valid = True
+            break
+
+        assert config_valid, "link speed/link width/pld_clk frequency/interface width combination not valid"
+
+        # configure port
+        self.upstream_port.max_link_speed = self.pcie_generation
+        self.upstream_port.max_link_width = self.pcie_link_width
+
+        # configure functions
+
+        self.make_function()
+
+        if self.pf0_msi_enable:
+            self.functions[0].msi_cap.msi_multiple_message_capable = (self.pf0_msi_count-1).bit_length()
+        else:
+            self.functions[0].deregister_capability(self.functions[0].msi_cap)
+
+        if self.pf0_msix_enable:
+            self.functions[0].msix_cap.msix_table_size = self.pf0_msix_table_size
+            self.functions[0].msix_cap.msix_table_bar_indicator_register = self.pf0_msix_table_bir
+            self.functions[0].msix_cap.msix_table_offset = self.pf0_msix_table_offset
+            self.functions[0].msix_cap.msix_pba_bar_indicator_register = self.pf0_msix_pba_bir
+            self.functions[0].msix_cap.msix_pba_offset = self.pf0_msix_pba_offset
+        else:
+            self.functions[0].deregister_capability(self.functions[0].msix_cap)
+
+        for f in self.functions:
+            f.pcie_cap.max_payload_size_supported = (self.max_payload_size//128-1).bit_length()
+            f.pcie_cap.extended_tag_supported = self.enable_extended_tag
+
+        self.bus_num = 0
+        self.device_num = 0
+
+        # fork coroutines
+
+        if self.coreclkout is not None:
+            cocotb.start_soon(Clock(self.coreclkout, int(1e9/self.pld_clk_frequency), units="ns").start())
+
+        if self.rx_source is not None:
+            cocotb.start_soon(self._run_rx_logic())
+        if self.tx_sink is not None:
+            cocotb.start_soon(self._run_tx_logic())
+        if self.tx_cred_datafcp is not None:
+            cocotb.start_soon(self._run_tx_fc_logic())
+        if self.app_msi_req is not None:
+            cocotb.start_soon(self._run_int_logic())
+        if self.tl_cfg_ctl is not None:
+            cocotb.start_soon(self._run_cfg_out_logic())
+
+        cocotb.start_soon(self._run_reset())
+
+    async def upstream_recv(self, tlp):
+        self.log.debug("Got downstream TLP: %r", tlp)
+
+        if tlp.fmt_type in {TlpType.CFG_READ_0, TlpType.CFG_WRITE_0}:
+            self.bus_num = tlp.completer_id.bus
+            self.device_num = tlp.completer_id.device
+
+            for f in self.functions:
+                if f.pcie_id == tlp.completer_id:
+                    await f.upstream_recv(tlp)
+                    return
+
+            tlp.release_fc()
+
+            self.log.warning("Function not found: failed to route config type 0 TLP: %r", tlp)
+        elif tlp.fmt_type in {TlpType.CFG_READ_1, TlpType.CFG_WRITE_1}:
+            tlp.release_fc()
+
+            self.log.warning("Malformed TLP: endpoint received config type 1 TLP: %r", tlp)
+        elif tlp.fmt_type in {TlpType.CPL, TlpType.CPL_DATA, TlpType.CPL_LOCKED, TlpType.CPL_LOCKED_DATA}:
+            for f in self.functions:
+                if f.pcie_id == tlp.requester_id:
+
+                    frame = S5PcieFrame.from_tlp(tlp)
+
+                    data_fc = tlp.get_data_credits()
+
+                    if self.rx_buf_cplh_fc_count+1 <= self.rx_buf_cplh_fc_limit and self.rx_buf_cpld_fc_count+data_fc <= self.rx_buf_cpld_fc_limit:
+                        self.rx_buf_cplh_fc_count += 1
+                        self.rx_buf_cpld_fc_count += data_fc
+                        await self.rx_queue.put((tlp, frame))
+                    else:
+                        self.log.warning("No space in RX completion buffer, dropping TLP: CPLH %d (limit %d), CPLD %d (limit %d)",
+                            self.rx_buf_cplh_fc_count, self.rx_buf_cplh_fc_limit, self.rx_buf_cpld_fc_count, self.rx_buf_cpld_fc_limit)
+
+                    tlp.release_fc()
+
+                    return
+
+            tlp.release_fc()
+
+            self.log.warning("Unexpected completion: failed to route completion to function: %r", tlp)
+            return  # no UR response for completion
+        elif tlp.fmt_type in {TlpType.IO_READ, TlpType.IO_WRITE}:
+            for f in self.functions:
+                bar = f.match_bar(tlp.address, True)
+                if bar:
+
+                    frame = S5PcieFrame.from_tlp(tlp)
+
+                    frame.bar = 1 << bar[0]
+
+                    await self.rx_queue.put((tlp, frame))
+
+                    tlp.release_fc()
+
+                    return
+
+            tlp.release_fc()
+
+            self.log.warning("No BAR match: IO request did not match any BARs: %r", tlp)
+        elif tlp.fmt_type in {TlpType.MEM_READ, TlpType.MEM_READ_64, TlpType.MEM_WRITE, TlpType.MEM_WRITE_64}:
+            for f in self.functions:
+                bar = f.match_bar(tlp.address)
+                if bar:
+
+                    frame = S5PcieFrame.from_tlp(tlp)
+
+                    frame.bar = 1 << bar[0]
+
+                    await self.rx_queue.put((tlp, frame))
+
+                    tlp.release_fc()
+
+                    return
+
+            tlp.release_fc()
+
+            if tlp.fmt_type in {TlpType.MEM_WRITE, TlpType.MEM_WRITE_64}:
+                self.log.warning("No BAR match: memory write request did not match any BARs: %r", tlp)
+                return  # no UR response for write request
+            else:
+                self.log.warning("No BAR match: memory read request did not match any BARs: %r", tlp)
+        else:
+            raise Exception("TODO")
+
+        cpl = Tlp.create_ur_completion_for_tlp(tlp, PcieId(self.bus_num, 0, 0))
+        self.log.debug("UR Completion: %r", cpl)
+        await self.upstream_send(cpl)
+
+    async def _run_reset(self):
+        # reset_status is synchronous to pld_clk (UG-01097_avst Table 5-6), and
+        # the reset sequence in Figure 7-2 is expressed in pld_clk cycles, so
+        # the whole sequence runs on pld_clk rather than on coreclkout.
+        clock_edge_event = RisingEdge(self.pld_clk)
+
+        # lane_act is a one-hot encoding of the negotiated link width
+        lane_act_val = {1: 0b0001, 2: 0b0010, 4: 0b0100, 8: 0b1000}[self.pcie_link_width]
+
+        while True:
+            await clock_edge_event
+            await clock_edge_event
+
+            # in reset: pld_clk_inuse is deasserted until the Transaction Layer
+            # is running on pld_clk, reset_status/clr_st are asserted
+            if self.pld_clk_inuse is not None:
+                self.pld_clk_inuse.value = 0
+            if self.serdes_pll_locked is not None:
+                self.serdes_pll_locked.value = 0
+            if self.reset_status is not None:
+                self.reset_status.value = 1
+            if self.clr_st is not None:
+                self.clr_st.value = 1
+            if self.dlup is not None:
+                self.dlup.value = 0
+            if self.ltssmstate is not None:
+                self.ltssmstate.value = 0x00  # Detect.Quiet
+            if self.lane_act is not None:
+                self.lane_act.value = 0
+            if self.currentspeed is not None:
+                self.currentspeed.value = 0
+
+            for f in self.functions:
+                f.pcie_cap.current_link_speed = 0
+                f.pcie_cap.negotiated_link_width = 0
+
+            if self.pin_perst is not None:
+                if not self.pin_perst.value:
+                    await RisingEdge(self.pin_perst)
+                await First(FallingEdge(self.pin_perst), Timer(100, 'ns'))
+                await First(FallingEdge(self.pin_perst), clock_edge_event)
+                if not self.pin_perst.value:
+                    continue
+            else:
+                await Timer(100, 'ns')
+                await clock_edge_event
+
+            # PLL locks, then the Transaction Layer starts using pld_clk
+            if self.serdes_pll_locked is not None:
+                self.serdes_pll_locked.value = 1
+            if self.pld_clk_inuse is not None:
+                self.pld_clk_inuse.value = 1
+
+            # crst/srst are released 32 cycles after pld_clk_inuse asserts
+            for _ in range(32):
+                await clock_edge_event
+
+            if self.reset_status is not None:
+                self.reset_status.value = 0
+            if self.clr_st is not None:
+                self.clr_st.value = 0
+            if self.dlup is not None:
+                self.dlup.value = 1
+            if self.ltssmstate is not None:
+                self.ltssmstate.value = 0x0f  # L0
+            if self.lane_act is not None:
+                self.lane_act.value = lane_act_val
+            if self.currentspeed is not None:
+                self.currentspeed.value = self.pcie_generation
+
+            # the core never populates these, but the Hard IP reports the
+            # negotiated values in Link Status (and hence on tl_cfg_sts), so
+            # fill them in from the configured link parameters
+            for f in self.functions:
+                f.pcie_cap.current_link_speed = self.pcie_generation
+                f.pcie_cap.negotiated_link_width = self.pcie_link_width
+
+            if self.pin_perst is not None:
+                await FallingEdge(self.pin_perst)
+            else:
+                return
+
+    async def _run_rx_logic(self):
+        clock_edge_event = RisingEdge(self.pld_clk)
+
+        while True:
+            tlp, frame = await self.rx_queue.get()
+
+            # rx_st_mask stalls only non-posted requests; posted requests and
+            # completions continue to be forwarded (UG-01097_avst Table 5-2).
+            # NOTE: the RX path is modeled as a single queue, so a stalled
+            # non-posted request also holds up TLPs queued behind it. The real
+            # Hard IP holds masked non-posted requests in the RX buffer and
+            # keeps draining posted traffic past them.
+            if self.rx_st_mask is not None and tlp.is_nonposted():
+                while self.rx_st_mask.value:
+                    await clock_edge_event
+
+            await self.rx_source.send(frame)
+
+            self.rx_buf_cplh_fc_count = max(self.rx_buf_cplh_fc_count-1, 0)
+            self.rx_buf_cpld_fc_count = max(self.rx_buf_cpld_fc_count-tlp.get_data_credits(), 0)
+
+    async def _run_tx_logic(self):
+        while True:
+            frame = await self.tx_sink.recv()
+            tlp = frame.to_tlp()
+            await self.send(tlp)
+
+    async def _run_tx_fc_logic(self):
+        clock_edge_event = RisingEdge(self.pld_clk)
+
+        while True:
+            fc = self.upstream_port.fc_state[0]
+
+            if self.tx_cred_hdrfcp is not None:
+                self.tx_cred_hdrfcp.value = fc.ph.tx_credits_available & 0xff
+            if self.tx_cred_datafcp is not None:
+                self.tx_cred_datafcp.value = fc.pd.tx_credits_available & 0xfff
+            if self.tx_cred_hdrfcnp is not None:
+                self.tx_cred_hdrfcnp.value = fc.nph.tx_credits_available & 0xff
+            if self.tx_cred_datafcnp is not None:
+                self.tx_cred_datafcnp.value = fc.npd.tx_credits_available & 0xfff
+            if self.tx_cred_hdrfccp is not None:
+                self.tx_cred_hdrfccp.value = fc.cplh.tx_credits_available & 0xff
+            if self.tx_cred_datafccp is not None:
+                self.tx_cred_datafccp.value = fc.cpld.tx_credits_available & 0xfff
+
+            await clock_edge_event
+
+    async def _run_int_logic(self):
+        clock_edge_event = RisingEdge(self.pld_clk)
+
+        while True:
+            await clock_edge_event
+
+            while not int(self.app_msi_req.value):
+                await RisingEdge(self.app_msi_req)
+                await clock_edge_event
+
+            app_msi_num = int(self.app_msi_num.value)
+            app_msi_tc = int(self.app_msi_tc.value)
+            await self.functions[0].msi_cap.issue_msi_interrupt(app_msi_num, tc=app_msi_tc)
+
+            self.app_msi_ack.value = 1
+            await clock_edge_event
+            self.app_msi_ack.value = 0
+
+            while int(self.app_msi_req.value):
+                await clock_edge_event
+
+    def _get_tl_cfg_ctl(self, addr):
+        """Return the 32-bit tl_cfg_ctl word for a given tl_cfg_add index.
+
+        Layout is taken from UG-01097_avst Figure 5-40 "Multiplexed
+        Configuration Register Information Available on tl_cfg_ctl".  Fields
+        marked in the datasheet as Root Port only read back as zero, since
+        this model only implements Endpoint operation.
+        """
+        func = self.functions[0]
+
+        if addr == 0x0:
+            # cfg_dev_ctrl[15:0] : cfg_dev_ctrl2[15:0]
+            dev_ctrl = bool(func.pcie_cap.correctable_error_reporting_enable)
+            dev_ctrl |= bool(func.pcie_cap.non_fatal_error_reporting_enable) << 1
+            dev_ctrl |= bool(func.pcie_cap.fatal_error_reporting_enable) << 2
+            dev_ctrl |= bool(func.pcie_cap.unsupported_request_reporting_enable) << 3
+            dev_ctrl |= bool(func.pcie_cap.enable_relaxed_ordering) << 4
+            dev_ctrl |= (func.pcie_cap.max_payload_size & 0x7) << 5
+            dev_ctrl |= bool(func.pcie_cap.extended_tag_field_enable) << 8
+            dev_ctrl |= bool(func.pcie_cap.enable_no_snoop) << 11
+            dev_ctrl |= (func.pcie_cap.max_read_request_size & 0x7) << 12
+
+            dev_ctrl2 = bool(func.pcie_cap.ari_forwarding_enable) << 5
+            dev_ctrl2 |= bool(func.pcie_cap.atomic_op_requester_enable) << 6
+            dev_ctrl2 |= bool(func.pcie_cap.ido_request_enable) << 8
+            dev_ctrl2 |= bool(func.pcie_cap.ido_completion_enable) << 9
+
+            return (dev_ctrl & 0xffff) << 16 | (dev_ctrl2 & 0xffff)
+
+        elif addr == 0x1:
+            # 16'h0000 : cfg_slot_ctrl[15:0] (Root Port only)
+            return 0
+
+        elif addr == 0x2:
+            # cfg_link_ctrl[15:0] : cfg_link_ctrl2[15:0]
+            link_ctrl = bool(func.pcie_cap.read_completion_boundary) << 3
+            link_ctrl |= bool(func.pcie_cap.link_disable) << 4
+            link_ctrl |= bool(func.pcie_cap.common_clock_configuration) << 6
+            link_ctrl |= bool(func.pcie_cap.extended_synch) << 7
+            link_ctrl |= bool(func.pcie_cap.hardware_autonomous_width_disable) << 9
+            link_ctrl |= bool(func.pcie_cap.link_bandwidth_management_interrupt_enable) << 10
+
+            link_ctrl2 = func.pcie_cap.target_link_speed & 0xf
+
+            return (link_ctrl & 0xffff) << 16 | (link_ctrl2 & 0xffff)
+
+        elif addr == 0x3:
+            # 8'h00 : cfg_prm_cmd[15:0] : cfg_root_ctrl[7:0] (RP only)
+            prm_cmd = bool(func.io_space_enable)
+            prm_cmd |= bool(func.memory_space_enable) << 1
+            prm_cmd |= bool(func.bus_master_enable) << 2
+            prm_cmd |= bool(func.parity_error_response_enable) << 6
+            prm_cmd |= bool(func.serr_enable) << 8
+            prm_cmd |= bool(func.interrupt_disable) << 10
+
+            return (prm_cmd & 0xffff) << 8
+
+        elif addr == 0x4:
+            # cfg_sec_ctrl : cfg_secbus : cfg_subbus (Root Port only)
+            return 0
+
+        elif addr == 0x5:
+            # cfg_msi_addr[11:0] : cfg_io_bas[19:0] (io_bas is Root Port only)
+            return (func.msi_cap.msi_message_address & 0xfff) << 20
+
+        elif addr == 0x6:
+            # cfg_msi_addr[43:32] : cfg_io_lim[19:0] (io_lim is Root Port only)
+            return ((func.msi_cap.msi_message_address >> 32) & 0xfff) << 20
+
+        elif addr == 0x7:
+            # 8'h00 : cfg_np_bas[11:0] : cfg_np_lim[11:0] (Root Port only)
+            return 0
+
+        elif addr == 0x8:
+            # cfg_pr_bas[31:0] (Root Port only)
+            return 0
+
+        elif addr == 0x9:
+            # cfg_msi_addr[31:12] : cfg_pr_bas[43:32] (pr_bas is RP only)
+            return ((func.msi_cap.msi_message_address >> 12) & 0xfffff) << 12
+
+        elif addr == 0xa:
+            # cfg_pr_lim[31:0] (Root Port only)
+            return 0
+
+        elif addr == 0xb:
+            # cfg_msi_addr[63:44] : cfg_pr_lim[43:32] (pr_lim is RP only)
+            return ((func.msi_cap.msi_message_address >> 44) & 0xfffff) << 12
+
+        elif addr == 0xc:
+            # cfg_pmcsr[31:0]
+            pmcsr = func.pm_cap.power_state & 0x3
+            pmcsr |= bool(func.pm_cap.no_soft_reset) << 3
+            pmcsr |= bool(func.pm_cap.pme_enable) << 8
+            pmcsr |= bool(func.pm_cap.pme_status) << 15
+            return pmcsr & 0xffffffff
+
+        elif addr == 0xd:
+            # cfg_msixcsr[15:0] : cfg_msicsr[15:0]
+            # cfg_msicsr field map is UG-01097_avst Figure 5-41 / Table 5-19
+            msicsr = bool(func.msi_cap.msi_enable)
+            msicsr |= (func.msi_cap.msi_multiple_message_capable & 0x7) << 1
+            msicsr |= (func.msi_cap.msi_multiple_message_enable & 0x7) << 4
+            msicsr |= bool(func.msi_cap.msi_64bit_address_capable) << 7
+            msicsr |= bool(func.msi_cap.msi_per_vector_mask_capable) << 8
+
+            # MSI-X Message Control, per the PCI Local Bus Specification
+            msixcsr = func.msix_cap.msix_table_size & 0x7ff
+            msixcsr |= bool(func.msix_cap.msix_function_mask) << 14
+            msixcsr |= bool(func.msix_cap.msix_enable) << 15
+
+            return (msixcsr & 0xffff) << 16 | (msicsr & 0xffff)
+
+        elif addr == 0xe:
+            # 6'h00 : tx_ecrcgen[25] : rx_ecrccheck[24] : cfg_tcvcmap[23:0]
+            # a single VC is implemented, so every TC maps to VC0 (all zeros)
+            val = bool(func.aer_ext_cap.ecrc_check_enable) << 24
+            val |= bool(func.aer_ext_cap.ecrc_generation_enable) << 25
+            return val
+
+        elif addr == 0xf:
+            # cfg_msi_data[15:0] : 3'b000 : cfg_busdev[12:0]
+            busdev = ((self.bus_num & 0xff) << 5) | (self.device_num & 0x1f)
+            return (func.msi_cap.msi_message_data & 0xffff) << 16 | busdev
+
+        return 0
+
+    def _get_tl_cfg_sts(self):
+        """Return the 53-bit tl_cfg_sts word (UG-01097_avst Table 5-17)."""
+        func = self.functions[0]
+
+        # [52:49] Device Status Register[3:0]
+        dev_sts = bool(func.pcie_cap.correctable_error_detected)
+        dev_sts |= bool(func.pcie_cap.nonfatal_error_detected) << 1
+        dev_sts |= bool(func.pcie_cap.fatal_error_detected) << 2
+        dev_sts |= bool(func.pcie_cap.unsupported_request_detected) << 3
+
+        # [46:31] Link Status Register[15:0]. Bit 13 (Data Link Layer link
+        # active) is defined as always 0 for Endpoints.
+        link_sts = func.pcie_cap.current_link_speed & 0xf
+        link_sts |= (func.pcie_cap.negotiated_link_width & 0x3f) << 4
+        link_sts |= bool(func.pcie_cap.link_training) << 11
+        link_sts |= bool(func.pcie_cap.slot_clock_configuration) << 12
+        link_sts |= bool(func.pcie_cap.link_bandwidth_management_status) << 14
+        link_sts |= bool(func.pcie_cap.link_autonomous_bandwidth_status) << 15
+
+        # [29:25] Status Register[15:11]
+        cmd_sts = bool(func.signaled_target_abort)
+        cmd_sts |= bool(func.received_target_abort) << 1
+        cmd_sts |= bool(func.received_master_abort) << 2
+        cmd_sts |= bool(func.signaled_system_error) << 3
+        cmd_sts |= bool(func.detected_parity_error) << 4
+
+        val = (dev_sts & 0xf) << 49
+        val |= (link_sts & 0xffff) << 31
+        val |= (cmd_sts & 0x1f) << 25
+        return val
+
+    async def _run_cfg_out_logic(self):
+        # The Configuration Space is presented to the Application Layer as a
+        # round-robin multiplex over tl_cfg_ctl, indexed by tl_cfg_add. The
+        # datasheet specifies that the index advances every 4 or 8 pld_clk
+        # cycles (Table 5-16 / Figure 5-39) so that the Application Layer can
+        # strobe-sample in the middle of each window; advancing it every cycle
+        # would break the sampling logic the datasheet recommends.
+        clock_edge_event = RisingEdge(self.pld_clk)
+
+        while True:
+            for addr in range(16):
+                self.tl_cfg_add.value = addr
+                self.tl_cfg_ctl.value = self._get_tl_cfg_ctl(addr)
+                if self.tl_cfg_sts is not None:
+                    self.tl_cfg_sts.value = self._get_tl_cfg_sts()
+
+                for _ in range(self.tl_cfg_update_cycles):
+                    await clock_edge_event

--- a/tests/pcie_s5/Makefile
+++ b/tests/pcie_s5/Makefile
@@ -1,0 +1,54 @@
+# Copyright (c) 2026 Anderson Ignacio da Silva
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+TOPLEVEL_LANG = verilog
+
+SIM ?= icarus
+WAVES ?= 0
+
+COCOTB_HDL_TIMEUNIT = 1ns
+COCOTB_HDL_TIMEPRECISION = 1ps
+
+DUT      = test_pcie_s5
+COCOTB_TEST_MODULES = $(DUT)
+COCOTB_TOPLEVEL     = $(DUT)
+MODULE   = $(COCOTB_TEST_MODULES)
+TOPLEVEL = $(COCOTB_TOPLEVEL)
+VERILOG_SOURCES  = $(DUT).v
+
+# module parameters
+export PARAM_DATA_WIDTH := 128
+export PARAM_PARITY_WIDTH := $(shell expr $(PARAM_DATA_WIDTH) / 8 )
+export PARAM_EMPTY_WIDTH := $(shell python -c "print((($(PARAM_DATA_WIDTH)//64)-1).bit_length())" )
+
+ifeq ($(SIM), icarus)
+	PLUSARGS += -fst
+
+	COMPILE_ARGS += $(foreach v,$(filter PARAM_%,$(.VARIABLES)),-P $(COCOTB_TOPLEVEL).$(subst PARAM_,,$(v))=$($(v)))
+else ifeq ($(SIM), verilator)
+	COMPILE_ARGS += $(foreach v,$(filter PARAM_%,$(.VARIABLES)),-G$(subst PARAM_,,$(v))=$($(v)))
+
+	ifeq ($(WAVES), 1)
+		COMPILE_ARGS += --trace-fst
+		VERILATOR_TRACE = 1
+	endif
+endif
+
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/tests/pcie_s5/test_pcie_s5.py
+++ b/tests/pcie_s5/test_pcie_s5.py
@@ -1,0 +1,832 @@
+#!/usr/bin/env python
+"""
+
+Copyright (c) 2026 Anderson Ignacio da Silva
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+"""
+
+import itertools
+import logging
+import mmap
+import os
+
+import cocotb_test.simulator
+import pytest
+
+import cocotb
+from cocotb.clock import Clock
+from cocotb.queue import Queue
+from cocotb.triggers import RisingEdge, FallingEdge, Timer, Event, First
+from cocotb.regression import TestFactory
+
+from cocotbext.pcie.core import RootComplex
+from cocotbext.pcie.intel.s5 import S5PcieDevice, S5RxBus, S5TxBus
+from cocotbext.pcie.intel.s5.interface import S5PcieFrame, S5PcieSource, S5PcieSink
+from cocotbext.pcie.core.tlp import Tlp, TlpType, CplStatus
+from cocotbext.pcie.core.utils import PcieId
+
+
+class TB:
+    def __init__(self, dut):
+        self.dut = dut
+
+        self.log = logging.getLogger("cocotb.tb")
+        self.log.setLevel(logging.DEBUG)
+
+        # Per UG-01097_avst Table 7-3, the 128-bit interface pairs with gen1 x8
+        # at 125 MHz and the 256-bit interface pairs with gen2 x8 at 125 MHz.
+        if len(dut.tx_st_data) == 128:
+            pcie_generation = 1
+        else:
+            pcie_generation = 2
+        cocotb.start_soon(Clock(dut.pld_clk, 8, units="ns").start())
+
+        # PCIe
+        self.rc = RootComplex()
+
+        self.dev = S5PcieDevice(
+            # configuration options
+            pcie_generation=pcie_generation,
+            pcie_link_width=8,
+            pld_clk_frequency=125e6,
+            pf_count=1,
+            max_payload_size=128,
+            enable_extended_tag=False,
+
+            pf0_msi_enable=True,
+            pf0_msi_count=32,
+
+            # signals
+            # Clocks
+            refclk=dut.refclk,
+            pld_clk=dut.pld_clk,
+            coreclkout=dut.coreclkout,
+
+            # Reset, status, and link training
+            npor=dut.npor,
+            pin_perst=dut.pin_perst,
+            reset_status=dut.reset_status,
+            clr_st=dut.clr_st,
+            serdes_pll_locked=dut.serdes_pll_locked,
+            pld_core_ready=dut.pld_core_ready,
+            pld_clk_inuse=dut.pld_clk_inuse,
+            dlup=dut.dlup,
+            dlup_exit=dut.dlup_exit,
+            hotrst_exit=dut.hotrst_exit,
+            l2_exit=dut.l2_exit,
+            ev128ns=dut.ev128ns,
+            ev1us=dut.ev1us,
+            lane_act=dut.lane_act,
+            currentspeed=dut.currentspeed,
+            ltssmstate=dut.ltssmstate,
+
+            # RX interface
+            rx_bus=S5RxBus.from_prefix(dut, "rx_st"),
+
+            # TX interface
+            tx_bus=S5TxBus.from_prefix(dut, "tx_st"),
+
+            # TX flow control
+            tx_cred_hdrfcp=dut.tx_cred_hdrfcp,
+            tx_cred_datafcp=dut.tx_cred_datafcp,
+            tx_cred_hdrfcnp=dut.tx_cred_hdrfcnp,
+            tx_cred_datafcnp=dut.tx_cred_datafcnp,
+            tx_cred_hdrfccp=dut.tx_cred_hdrfccp,
+            tx_cred_datafccp=dut.tx_cred_datafccp,
+            tx_cred_fchipcons=dut.tx_cred_fchipcons,
+            tx_cred_fc_infinite=dut.tx_cred_fc_infinite,
+            tx_cons_cred_sel=dut.tx_cons_cred_sel,
+            ko_cpl_spc_header=dut.ko_cpl_spc_header,
+            ko_cpl_spc_data=dut.ko_cpl_spc_data,
+
+            # Error signals
+            derr_cor_ext_rcv0=dut.derr_cor_ext_rcv0,
+            derr_rpl=dut.derr_rpl,
+            derr_cor_ext_rpl0=dut.derr_cor_ext_rpl0,
+            rxfc_cplbuf_ovf=dut.rxfc_cplbuf_ovf,
+
+            # Interrupts for endpoints
+            app_msi_req=dut.app_msi_req,
+            app_msi_ack=dut.app_msi_ack,
+            app_msi_tc=dut.app_msi_tc,
+            app_msi_num=dut.app_msi_num,
+            app_int_sts=dut.app_int_sts,
+            app_int_ack=dut.app_int_ack,
+
+            # Completion side band signals
+            cpl_err=dut.cpl_err,
+            cpl_pending=dut.cpl_pending,
+
+            # Transaction layer configuration space signals
+            tl_cfg_add=dut.tl_cfg_add,
+            tl_cfg_ctl=dut.tl_cfg_ctl,
+            tl_cfg_sts=dut.tl_cfg_sts,
+
+            # Power management
+            pme_to_cr=dut.pme_to_cr,
+            pme_to_sr=dut.pme_to_sr,
+            pm_event=dut.pm_event,
+            pm_data=dut.pm_data,
+            pm_auxpwr=dut.pm_auxpwr,
+        )
+
+        self.dev.log.setLevel(logging.DEBUG)
+
+        dut.npor.setimmediatevalue(1)
+        dut.pin_perst.setimmediatevalue(1)
+        dut.pld_core_ready.setimmediatevalue(1)
+        dut.refclk.setimmediatevalue(0)
+        dut.rx_st_mask.setimmediatevalue(0)
+        dut.tx_cons_cred_sel.setimmediatevalue(0)
+        dut.app_msi_req.setimmediatevalue(0)
+        dut.app_msi_tc.setimmediatevalue(0)
+        dut.app_msi_num.setimmediatevalue(0)
+        dut.app_int_sts.setimmediatevalue(0)
+        dut.cpl_err.setimmediatevalue(0)
+        dut.cpl_pending.setimmediatevalue(0)
+        dut.pme_to_cr.setimmediatevalue(0)
+        dut.pm_event.setimmediatevalue(0)
+        dut.pm_data.setimmediatevalue(0)
+        dut.pm_auxpwr.setimmediatevalue(0)
+
+        self.rc.make_port().connect(self.dev)
+
+        # user logic
+        self.tx_source = S5PcieSource(S5TxBus.from_prefix(dut, "tx_st"), dut.pld_clk)
+        self.tx_source.ready_latency = 2
+        self.rx_sink = S5PcieSink(S5RxBus.from_prefix(dut, "rx_st"), dut.pld_clk)
+        self.rx_sink.ready_latency = 3
+
+        self.regions = [None]*6
+        self.regions[0] = mmap.mmap(-1, 1024*1024)
+        self.regions[1] = mmap.mmap(-1, 1024*1024)
+        self.regions[3] = mmap.mmap(-1, 1024)
+
+        self.current_tag = 0
+        self.tag_count = 256
+        self.tag_active = [False]*256
+        self.tag_release = Event()
+
+        self.rx_cpl_queues = [Queue() for k in range(256)]
+        self.rx_cpl_sync = [Event() for k in range(256)]
+
+        self.cfg_regs = [None]*16
+
+        self.dev_bus_num = 0
+        self.dev_device_num = 0
+        self.dev_max_payload = 0
+        self.dev_max_read_req = 0
+        self.dev_memory_space_enable = 0
+        self.dev_bus_master_enable = 0
+        self.dev_interrupt_disable = 0
+        self.dev_msi_address = 0
+        self.dev_msi_data = 0
+        self.dev_msi_enable = 0
+        self.dev_msi_multi_msg_enable = 0
+        self.dev_msix_enable = 0
+        self.dev_msix_function_mask = 0
+
+        self.dev.functions[0].configure_bar(0, len(self.regions[0]))
+        self.dev.functions[0].configure_bar(1, len(self.regions[1]), True, True)
+        self.dev.functions[0].configure_bar(3, len(self.regions[3]), False, False, True)
+
+        cocotb.start_soon(self._run_rx_tlp())
+        cocotb.start_soon(self._run_cfg())
+
+    def set_idle_generator(self, generator=None):
+        if generator:
+            self.dev.rx_source.set_pause_generator(generator())
+
+    def set_backpressure_generator(self, generator=None):
+        if generator:
+            self.dev.tx_sink.set_pause_generator(generator())
+
+    async def recv_cpl(self, tag, timeout=0, timeout_unit='ns'):
+        queue = self.rx_cpl_queues[tag]
+        sync = self.rx_cpl_sync[tag]
+
+        if not queue.empty():
+            return queue.get_nowait()
+
+        sync.clear()
+        if timeout:
+            await First(sync.wait(), Timer(timeout, timeout_unit))
+        else:
+            await sync.wait()
+
+        if not queue.empty():
+            return queue.get_nowait()
+
+        return None
+
+    async def alloc_tag(self):
+        tag_count = min(256 if self.dev.functions[0].pcie_cap.extended_tag_field_enable else 32, self.tag_count)
+
+        while True:
+            tag = self.current_tag
+            for k in range(tag_count):
+                tag = (tag + 1) % tag_count
+                if not self.tag_active[tag]:
+                    self.tag_active[tag] = True
+                    self.current_tag = tag
+                    return tag
+
+            self.tag_release.clear()
+            await self.tag_release.wait()
+
+    def release_tag(self, tag):
+        assert self.tag_active[tag]
+        self.tag_active[tag] = False
+        self.tag_release.set()
+
+    async def perform_posted_operation(self, req):
+        await self.tx_source.send(S5PcieFrame.from_tlp(req))
+
+    async def perform_nonposted_operation(self, req, timeout=0, timeout_unit='ns'):
+        completions = []
+
+        req.tag = await self.alloc_tag()
+
+        await self.tx_source.send(S5PcieFrame.from_tlp(req))
+
+        while True:
+            cpl = await self.recv_cpl(req.tag, timeout, timeout_unit)
+
+            if not cpl:
+                break
+
+            completions.append(cpl)
+
+            if cpl.status != CplStatus.SC:
+                break
+            elif req.fmt_type in {TlpType.MEM_READ, TlpType.MEM_READ_64}:
+                if cpl.byte_count <= cpl.length*4 - (cpl.lower_address & 0x3):
+                    break
+
+                if cpl.fmt_type in {TlpType.CPL, TlpType.CPL_LOCKED}:
+                    break
+
+            else:
+                break
+
+        self.release_tag(req.tag)
+
+        return completions
+
+    async def dma_mem_write(self, addr, data, timeout=0, timeout_unit='ns'):
+        n = 0
+
+        zero_len = len(data) == 0
+        if zero_len:
+            data = b'\x00'
+
+        while n < len(data):
+            req = Tlp()
+            if addr > 0xffffffff:
+                req.fmt_type = TlpType.MEM_WRITE_64
+            else:
+                req.fmt_type = TlpType.MEM_WRITE
+            req.requester_id = PcieId(self.dev_bus_num, self.dev_device_num, 0)
+
+            first_pad = addr % 4
+            byte_length = len(data)-n
+            byte_length = min(byte_length, (128 << self.dev_max_payload)-first_pad)
+            byte_length = min(byte_length, 0x1000 - (addr & 0xfff))
+            req.set_addr_be_data(addr, data[n:n+byte_length])
+
+            if zero_len:
+                req.first_be = 0
+
+            await self.perform_posted_operation(req)
+
+            n += byte_length
+            addr += byte_length
+
+    async def dma_mem_read(self, addr, length, timeout=0, timeout_unit='ns'):
+        data = bytearray()
+        n = 0
+
+        zero_len = length <= 0
+        if zero_len:
+            length = 1
+
+        op_list = []
+
+        while n < length:
+            req = Tlp()
+            if addr > 0xffffffff:
+                req.fmt_type = TlpType.MEM_READ_64
+            else:
+                req.fmt_type = TlpType.MEM_READ
+            req.requester_id = PcieId(self.dev_bus_num, self.dev_device_num, 0)
+
+            first_pad = addr % 4
+            byte_length = length-n
+            if byte_length > (128 << self.dev_max_read_req) - first_pad:
+                byte_length = min(byte_length, (128 << self.dev_max_read_req) - (addr & 0x7f))
+            byte_length = min(byte_length, 0x1000 - (addr & 0xfff))
+            req.set_addr_be(addr, byte_length)
+
+            if zero_len:
+                req.first_be = 0
+
+            op_list.append((byte_length, cocotb.start_soon(self.perform_nonposted_operation(req, timeout, timeout_unit))))
+
+            n += byte_length
+            addr += byte_length
+
+        for byte_length, op in op_list:
+            cpl_list = await op.join()
+
+            m = 0
+
+            while m < byte_length:
+                if not cpl_list:
+                    raise Exception("Timeout")
+
+                cpl = cpl_list.pop(0)
+
+                if cpl.status != CplStatus.SC:
+                    raise Exception("Unsuccessful completion")
+
+                d = cpl.get_data()
+
+                offset = cpl.lower_address & 3
+                data.extend(d[offset:offset+cpl.byte_count])
+
+                m += len(d)-offset
+
+        if zero_len:
+            return b''
+
+        return bytes(data[:length])
+
+    async def _run_rx_tlp(self):
+        while True:
+            frame = await self.rx_sink.recv()
+
+            tlp = frame.to_tlp()
+
+            self.log.debug("RX TLP: %s", repr(tlp))
+
+            if tlp.fmt_type in {TlpType.CPL, TlpType.CPL_DATA, TlpType.CPL_LOCKED, TlpType.CPL_LOCKED_DATA}:
+                self.log.info("Completion")
+
+                self.rx_cpl_queues[tlp.tag].put_nowait(tlp)
+                self.rx_cpl_sync[tlp.tag].set()
+
+            elif tlp.fmt_type in {TlpType.MEM_READ, TlpType.MEM_READ_64}:
+                self.log.info("Memory read")
+
+                region = frame.bar.bit_length()-1
+                addr = tlp.address % len(self.regions[region])
+                length = tlp.length
+
+                data = self.regions[region][addr:addr+length*4]
+
+                m = 0
+                n = 0
+                addr = tlp.address+tlp.get_first_be_offset()
+                dw_length = tlp.length
+                byte_length = tlp.get_be_byte_count()
+
+                while m < dw_length:
+                    cpl = Tlp.create_completion_data_for_tlp(tlp, PcieId(self.dev_bus_num, 0, 0))
+
+                    cpl_dw_length = dw_length - m
+                    cpl_byte_length = byte_length - n
+                    cpl.byte_count = cpl_byte_length
+                    if cpl_dw_length > 32 << self.dev_max_payload:
+                        cpl_dw_length = 32 << self.dev_max_payload
+                        cpl_dw_length -= (addr & 0x7c) >> 2
+
+                    cpl.lower_address = addr & 0x7f
+
+                    cpl.set_data(data[m*4:(m+cpl_dw_length)*4])
+
+                    self.log.debug("Completion: %s", repr(cpl))
+                    await self.tx_source.send(S5PcieFrame.from_tlp(cpl))
+
+                    m += cpl_dw_length
+                    n += cpl_dw_length*4 - (addr & 3)
+                    addr += cpl_dw_length*4 - (addr & 3)
+
+            elif tlp.fmt_type in {TlpType.MEM_WRITE, TlpType.MEM_WRITE_64}:
+                self.log.info("Memory write")
+
+                region = frame.bar.bit_length()-1
+                addr = tlp.address % len(self.regions[region])
+                offset = 0
+                start_offset = None
+                mask = tlp.first_be
+                length = tlp.length
+
+                data = tlp.get_data()
+
+                for k in range(4):
+                    if mask & (1 << k):
+                        if start_offset is None:
+                            start_offset = offset
+                    else:
+                        if start_offset is not None and offset != start_offset:
+                            self.regions[region][addr+start_offset:addr+offset] = data[start_offset:offset]
+                        start_offset = None
+
+                    offset += 1
+
+                if length > 2:
+                    if start_offset is None:
+                        start_offset = offset
+                    offset += (length-2)*4
+
+                if length > 1:
+                    mask = tlp.last_be
+
+                    for k in range(4):
+                        if mask & (1 << k):
+                            if start_offset is None:
+                                start_offset = offset
+                        else:
+                            if start_offset is not None and offset != start_offset:
+                                self.regions[region][addr+start_offset:addr+offset] = data[start_offset:offset]
+                            start_offset = None
+
+                        offset += 1
+
+                if start_offset is not None and offset != start_offset:
+                    self.regions[region][addr+start_offset:addr+offset] = data[start_offset:offset]
+
+    async def _run_cfg(self):
+        # tl_cfg_add/tl_cfg_ctl are multi-cycle paths that hold each index for
+        # several pld_clk cycles. Sample in the middle of the window, as the
+        # datasheet's recommended Application Layer RTL does (Figure 5-39).
+        prev_addr = None
+
+        while True:
+            await RisingEdge(self.dut.pld_clk)
+
+            try:
+                addr = int(self.dut.tl_cfg_add.value)
+            except ValueError:
+                continue
+
+            if addr == prev_addr:
+                continue
+            prev_addr = addr
+
+            # wait out half of the update window before capturing
+            for _ in range(4):
+                await RisingEdge(self.dut.pld_clk)
+
+            try:
+                addr = int(self.dut.tl_cfg_add.value)
+                ctl = int(self.dut.tl_cfg_ctl.value)
+            except ValueError:
+                continue
+
+            self.cfg_regs[addr] = ctl
+
+            if addr == 0x0:
+                self.dev_max_payload = (ctl >> 21) & 0x7
+                self.dev_max_read_req = (ctl >> 28) & 0x7
+            elif addr == 0x3:
+                prm_cmd = (ctl >> 8) & 0xffff
+                self.dev_memory_space_enable = (prm_cmd >> 1) & 1
+                self.dev_bus_master_enable = (prm_cmd >> 2) & 1
+                self.dev_interrupt_disable = (prm_cmd >> 10) & 1
+            elif addr == 0x5:
+                self.dev_msi_address = ((self.dev_msi_address & ~0xfff)
+                                        | ((ctl >> 20) & 0xfff))
+            elif addr == 0x9:
+                self.dev_msi_address = ((self.dev_msi_address & ~(0xfffff << 12))
+                                        | (((ctl >> 12) & 0xfffff) << 12))
+            elif addr == 0x6:
+                self.dev_msi_address = ((self.dev_msi_address & ~(0xfff << 32))
+                                        | (((ctl >> 20) & 0xfff) << 32))
+            elif addr == 0xb:
+                self.dev_msi_address = ((self.dev_msi_address & ~(0xfffff << 44))
+                                        | (((ctl >> 12) & 0xfffff) << 44))
+            elif addr == 0xd:
+                msicsr = ctl & 0xffff
+                msixcsr = (ctl >> 16) & 0xffff
+                self.dev_msi_enable = msicsr & 1
+                self.dev_msi_multi_msg_enable = (msicsr >> 4) & 0x7
+                self.dev_msix_enable = (msixcsr >> 15) & 1
+                self.dev_msix_function_mask = (msixcsr >> 14) & 1
+            elif addr == 0xf:
+                self.dev_msi_data = (ctl >> 16) & 0xffff
+                self.dev_bus_num = (ctl >> 5) & 0xff
+                self.dev_device_num = ctl & 0x1f
+
+
+async def run_test_mem(dut, idle_inserter=None, backpressure_inserter=None):
+
+    tb = TB(dut)
+
+    tb.set_idle_generator(idle_inserter)
+    tb.set_backpressure_generator(backpressure_inserter)
+
+    await FallingEdge(dut.reset_status)
+    await Timer(100, 'ns')
+
+    await tb.rc.enumerate()
+
+    dev = tb.rc.find_device(tb.dev.functions[0].pcie_id)
+    await dev.enable_device()
+
+    dev_bar0 = dev.bar_window[0]
+    dev_bar1 = dev.bar_window[1]
+
+    for length in list(range(0, 32))+[1024]:
+        for offset in list(range(8))+list(range(4096-8, 4096)):
+            tb.log.info("Memory operation (32-bit BAR) length: %d offset: %d", length, offset)
+            test_data = bytearray([x % 256 for x in range(length)])
+
+            await dev_bar0.write(offset, test_data, timeout=100)
+            await dev_bar0.read(offset, 0, timeout=5000)
+            assert tb.regions[0][offset:offset+length] == test_data
+
+            assert await dev_bar0.read(offset, length, timeout=5000) == test_data
+
+    for length in list(range(0, 32))+[1024]:
+        for offset in list(range(8))+list(range(4096-8, 4096)):
+            tb.log.info("Memory operation (64-bit BAR) length: %d offset: %d", length, offset)
+            test_data = bytearray([x % 256 for x in range(length)])
+
+            await dev_bar1.write(offset, test_data, timeout=100)
+            await dev_bar1.read(offset, 0, timeout=5000)
+            assert tb.regions[1][offset:offset+length] == test_data
+
+            assert await dev_bar1.read(offset, length, timeout=5000) == test_data
+
+    await RisingEdge(dut.pld_clk)
+    await RisingEdge(dut.pld_clk)
+
+
+async def run_test_dma(dut, idle_inserter=None, backpressure_inserter=None):
+
+    tb = TB(dut)
+
+    mem = tb.rc.mem_pool.alloc_region(16*1024*1024)
+    mem_base = mem.get_absolute_address(0)
+
+    tb.set_idle_generator(idle_inserter)
+    tb.set_backpressure_generator(backpressure_inserter)
+
+    await FallingEdge(dut.reset_status)
+    await Timer(100, 'ns')
+
+    await tb.rc.enumerate()
+
+    dev = tb.rc.find_device(tb.dev.functions[0].pcie_id)
+    await dev.enable_device()
+    await dev.set_master()
+
+    for length in list(range(0, 32))+[1024]:
+        for offset in list(range(8))+list(range(4096-8, 4096)):
+            tb.log.info("Memory operation (DMA) length: %d offset: %d", length, offset)
+            addr = mem_base+offset
+            test_data = bytearray([x % 256 for x in range(length)])
+
+            await tb.dma_mem_write(addr, test_data, 5000, 'ns')
+            await tb.dma_mem_read(addr, 0, 5000, 'ns')
+            assert mem[offset:offset+length] == test_data
+
+            assert await tb.dma_mem_read(addr, length, 5000, 'ns') == test_data
+
+    await RisingEdge(dut.pld_clk)
+    await RisingEdge(dut.pld_clk)
+
+
+async def run_test_msi(dut, idle_inserter=None, backpressure_inserter=None):
+
+    tb = TB(dut)
+
+    tb.set_idle_generator(idle_inserter)
+    tb.set_backpressure_generator(backpressure_inserter)
+
+    await FallingEdge(dut.reset_status)
+    await Timer(100, 'ns')
+
+    await tb.rc.enumerate()
+
+    dev = tb.rc.find_device(tb.dev.functions[0].pcie_id)
+    await dev.enable_device()
+    await dev.set_master()
+    await dev.alloc_irq_vectors(32, 32)
+
+    await Timer(100, 'ns')
+
+    for k in range(32):
+        tb.log.info("Send MSI %d", k)
+
+        # the Hard IP emits the MSI TLP before it asserts app_msi_ack, so the
+        # interrupt can be delivered before the handshake completes; arm the
+        # event before requesting the interrupt to avoid losing it
+        event = dev.msi_vectors[k].event
+        event.clear()
+
+        await RisingEdge(dut.pld_clk)
+        dut.app_msi_req.value = 1
+        dut.app_msi_tc.value = 0
+        dut.app_msi_num.value = k
+
+        while not int(dut.app_msi_ack.value):
+            await RisingEdge(dut.pld_clk)
+
+        dut.app_msi_req.value = 0
+        await RisingEdge(dut.pld_clk)
+
+        await event.wait()
+
+    await RisingEdge(dut.pld_clk)
+    await RisingEdge(dut.pld_clk)
+
+
+async def run_test_cfg(dut, idle_inserter=None, backpressure_inserter=None):
+
+    tb = TB(dut)
+
+    tb.set_idle_generator(idle_inserter)
+    tb.set_backpressure_generator(backpressure_inserter)
+
+    await FallingEdge(dut.reset_status)
+    await Timer(100, 'ns')
+
+    await tb.rc.enumerate()
+
+    dev = tb.rc.find_device(tb.dev.functions[0].pcie_id)
+    await dev.enable_device()
+    await dev.set_master()
+    await dev.alloc_irq_vectors(32, 32)
+
+    func = tb.dev.functions[0]
+
+    # let the multiplex walk every index at least once
+    await Timer(16*8*8*2, 'ns')
+
+    assert None not in tb.cfg_regs, \
+        f"tl_cfg_add never presented every index: {tb.cfg_regs}"
+
+    tb.log.info("Captured tl_cfg_ctl: %s", [hex(x) for x in tb.cfg_regs])
+
+    # index 0x0 - Device Control / Device Control 2
+    assert tb.dev_max_payload == func.pcie_cap.max_payload_size
+    assert tb.dev_max_read_req == func.pcie_cap.max_read_request_size
+
+    # index 0x3 - Primary Command register
+    assert tb.dev_memory_space_enable == bool(func.memory_space_enable)
+    assert tb.dev_bus_master_enable == bool(func.bus_master_enable)
+    assert tb.dev_bus_master_enable, "bus master enable not visible on tl_cfg_ctl"
+    assert tb.dev_interrupt_disable == bool(func.interrupt_disable)
+
+    # indices 0x5/0x6/0x9/0xb - MSI address, reassembled from four slices
+    assert tb.dev_msi_address == func.msi_cap.msi_message_address, \
+        f"MSI address {tb.dev_msi_address:#x} != {func.msi_cap.msi_message_address:#x}"
+
+    # index 0xd - MSI / MSI-X control, index 0xf - MSI data and bus/device
+    assert tb.dev_msi_enable == bool(func.msi_cap.msi_enable)
+    assert tb.dev_msi_multi_msg_enable == func.msi_cap.msi_multiple_message_enable
+    assert tb.dev_msi_data == func.msi_cap.msi_message_data
+    assert tb.dev_bus_num == func.pcie_id.bus
+    assert tb.dev_device_num == func.pcie_id.device
+
+    # tl_cfg_sts carries the Link Status register in bits [46:31]. Compare
+    # against the configured link parameters rather than against the model's
+    # own capability fields, so this cannot pass by both sides reading zero.
+    sts = int(dut.tl_cfg_sts.value)
+    link_sts = (sts >> 31) & 0xffff
+    assert (link_sts & 0xf) == tb.dev.pcie_generation, \
+        f"link speed {link_sts & 0xf} != gen {tb.dev.pcie_generation}"
+    assert ((link_sts >> 4) & 0x3f) == tb.dev.pcie_link_width, \
+        f"negotiated width {(link_sts >> 4) & 0x3f} != x{tb.dev.pcie_link_width}"
+
+    await RisingEdge(dut.pld_clk)
+    await RisingEdge(dut.pld_clk)
+
+
+async def run_test_rx_mask(dut, idle_inserter=None, backpressure_inserter=None):
+
+    tb = TB(dut)
+
+    await FallingEdge(dut.reset_status)
+    await Timer(100, 'ns')
+
+    await tb.rc.enumerate()
+
+    dev = tb.rc.find_device(tb.dev.functions[0].pcie_id)
+    await dev.enable_device()
+
+    dev_bar0 = dev.bar_window[0]
+
+    # rx_st_mask stalls non-posted requests only, so a posted write must still
+    # land while it is asserted
+    dut.rx_st_mask.value = 1
+    await RisingEdge(dut.pld_clk)
+
+    test_data = b'\xde\xad\xbe\xef'
+    await dev_bar0.write(0, test_data, timeout=5000)
+    await Timer(2000, 'ns')
+    assert tb.regions[0][0:4] == test_data, "posted write blocked by rx_st_mask"
+
+    # a non-posted read must not complete until the mask is released.
+    # Completion is tracked with an Event rather than Task.done() so this
+    # works across the cocotb versions the package supports.
+    read_done = Event()
+    read_result = {}
+
+    async def _masked_read():
+        read_result['data'] = await dev_bar0.read(0, 4, timeout=20000)
+        read_done.set()
+
+    cocotb.start_soon(_masked_read())
+
+    await Timer(2000, 'ns')
+    assert not read_done.is_set(), "non-posted request not stalled by rx_st_mask"
+
+    dut.rx_st_mask.value = 0
+    await read_done.wait()
+    assert read_result['data'] == test_data
+
+    await RisingEdge(dut.pld_clk)
+    await RisingEdge(dut.pld_clk)
+
+
+def cycle_pause():
+    return itertools.cycle([1, 1, 1, 0])
+
+
+if getattr(cocotb, 'top', None) is not None:
+
+    for test in [
+                run_test_mem,
+                run_test_dma,
+                run_test_msi,
+            ]:
+
+        factory = TestFactory(test)
+        factory.add_option(("idle_inserter", "backpressure_inserter"), [(None, None), (cycle_pause, cycle_pause)])
+        factory.generate_tests()
+
+    for test in [
+                run_test_cfg,
+                run_test_rx_mask,
+            ]:
+
+        factory = TestFactory(test)
+        factory.generate_tests()
+
+
+# cocotb-test
+
+tests_dir = os.path.dirname(__file__)
+
+
+@pytest.mark.parametrize("data_width", [128, 256])
+def test_pcie_s5(request, data_width):
+    dut = "test_pcie_s5"
+    module = os.path.splitext(os.path.basename(__file__))[0]
+    toplevel = dut
+
+    verilog_sources = [
+        os.path.join(tests_dir, f"{dut}.v"),
+    ]
+
+    parameters = {}
+
+    parameters['DATA_WIDTH'] = data_width
+    parameters['PARITY_WIDTH'] = parameters['DATA_WIDTH'] // 8
+    parameters['EMPTY_WIDTH'] = ((parameters['DATA_WIDTH'] // 64) - 1).bit_length()
+
+    extra_env = {f'PARAM_{k}': str(v) for k, v in parameters.items()}
+
+    sim_build = os.path.join(tests_dir, "sim_build",
+        request.node.name.replace('[', '-').replace(']', ''))
+
+    cocotb_test.simulator.run(
+        python_search=[tests_dir],
+        verilog_sources=verilog_sources,
+        toplevel=toplevel,
+        module=module,
+        parameters=parameters,
+        sim_build=sim_build,
+        extra_env=extra_env,
+    )

--- a/tests/pcie_s5/test_pcie_s5.v
+++ b/tests/pcie_s5/test_pcie_s5.v
@@ -1,0 +1,126 @@
+/*
+
+Copyright (c) 2026 Anderson Ignacio da Silva
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+// Language: Verilog 2001
+
+`resetall
+`timescale 1ns / 1ns
+`default_nettype none
+
+/*
+ * Intel Stratix V Hard IP for PCI Express (Avalon-ST) core model test module
+ */
+module test_pcie_s5 #
+(
+    parameter DATA_WIDTH = 128,
+    parameter PARITY_WIDTH = DATA_WIDTH/8,
+    parameter EMPTY_WIDTH = $clog2(DATA_WIDTH/64)
+)
+(
+    // Clocks
+    input  wire                      refclk,
+    input  wire                      pld_clk,
+    output wire                      coreclkout,
+    // Reset, status, and link training
+    input  wire                      npor,
+    input  wire                      pin_perst,
+    output wire                      reset_status,
+    output wire                      clr_st,
+    output wire                      serdes_pll_locked,
+    input  wire                      pld_core_ready,
+    output wire                      pld_clk_inuse,
+    output wire                      dlup,
+    output wire                      dlup_exit,
+    output wire                      hotrst_exit,
+    output wire                      l2_exit,
+    output wire                      ev128ns,
+    output wire                      ev1us,
+    output wire [3:0]                lane_act,
+    output wire [1:0]                currentspeed,
+    output wire [4:0]                ltssmstate,
+    // RX interface
+    output wire [DATA_WIDTH-1:0]     rx_st_data,
+    output wire                      rx_st_sop,
+    output wire                      rx_st_eop,
+    output wire                      rx_st_valid,
+    input  wire                      rx_st_ready,
+    output wire [EMPTY_WIDTH-1:0]    rx_st_empty,
+    output wire                      rx_st_err,
+    output wire [7:0]                rx_st_bar,
+    input  wire                      rx_st_mask,
+    output wire [PARITY_WIDTH-1:0]   rx_st_parity,
+    // TX interface
+    input  wire [DATA_WIDTH-1:0]     tx_st_data,
+    input  wire                      tx_st_sop,
+    input  wire                      tx_st_eop,
+    input  wire                      tx_st_valid,
+    output wire                      tx_st_ready,
+    input  wire [EMPTY_WIDTH-1:0]    tx_st_empty,
+    input  wire                      tx_st_err,
+    input  wire [PARITY_WIDTH-1:0]   tx_st_parity,
+    // TX flow control
+    output wire [7:0]                tx_cred_hdrfcp,
+    output wire [11:0]               tx_cred_datafcp,
+    output wire [7:0]                tx_cred_hdrfcnp,
+    output wire [11:0]               tx_cred_datafcnp,
+    output wire [7:0]                tx_cred_hdrfccp,
+    output wire [11:0]               tx_cred_datafccp,
+    output wire [5:0]                tx_cred_fchipcons,
+    output wire [5:0]                tx_cred_fc_infinite,
+    input  wire                      tx_cons_cred_sel,
+    output wire [7:0]                ko_cpl_spc_header,
+    output wire [11:0]               ko_cpl_spc_data,
+    // Error signals
+    output wire                      derr_cor_ext_rcv0,
+    output wire                      derr_rpl,
+    output wire                      derr_cor_ext_rpl0,
+    output wire                      rxfc_cplbuf_ovf,
+    // Interrupts for endpoints
+    input  wire                      app_msi_req,
+    output wire                      app_msi_ack,
+    input  wire [2:0]                app_msi_tc,
+    input  wire [4:0]                app_msi_num,
+    input  wire                      app_int_sts,
+    output wire                      app_int_ack,
+    // Interrupts for root ports
+    output wire [3:0]                int_status,
+    output wire                      serr_out,
+    // Completion side band signals
+    input  wire [6:0]                cpl_err,
+    input  wire                      cpl_pending,
+    // Transaction layer configuration space signals
+    output wire [3:0]                tl_cfg_add,
+    output wire [31:0]               tl_cfg_ctl,
+    output wire [52:0]               tl_cfg_sts,
+    // Power management
+    input  wire                      pme_to_cr,
+    output wire                      pme_to_sr,
+    input  wire                      pm_event,
+    input  wire [9:0]                pm_data,
+    input  wire                      pm_auxpwr
+);
+
+endmodule
+
+`resetall


### PR DESCRIPTION
## Summary
- Adds `cocotbext.pcie.intel.s5`: a BFM model for the Intel Stratix V Hard IP for PCI Express, Avalon-ST interface, following the same structure as the existing `cocotbext.pcie.intel.s10` model (128-bit and 256-bit widths; device-only, single physical function).
- TLP framing follows the qword-aligned-address timing described in the Stratix V Avalon-ST user guide (UG-01097), including the address-bit-2-dependent header/payload dword padding.
- Adds a test suite under `tests/pcie_s5` mirroring the existing `tests/pcie_s10` structure.
- Documents the new module and its scope/limitations in the README.
